### PR TITLE
Allow running this as a normal user

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -6,6 +6,7 @@
     name:
       - xorriso
     state: present
+  become: true
 
 - name: Extract boot files from the source ISO
   block:


### PR DESCRIPTION
The `xorriso` installation is missing `become: true` -- add it so we can run this as a normal user with `ansible-playbook -K`

Signed-off-by: Michel Alexandre Salim <michel@michel-slm.name>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gadamiak/build_boot_iso/1)
<!-- Reviewable:end -->
